### PR TITLE
Fix dockerfiles for docker deployment guide

### DIFF
--- a/docs/deployment/docker/_partials/_dockerfile-npm.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-npm.mdx
@@ -18,7 +18,7 @@ WORKDIR /opt/docusaurus
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the development server.
-CMD [ -d "node_modules" ] && npm run start || npm run install && npm run start --host 0.0.0.0
+CMD [ -d "node_modules" ] && npm run start --host 0.0.0.0 || npm run install && npm run start --host 0.0.0.0
 
 # Stage 2b: Production build mode.
 FROM base as prod
@@ -36,7 +36,7 @@ FROM prod as serve
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the production server.
-CMD ["npm", "run", "serve", "--host", "0.0.0.0", "--no-open"]
+CMD ["npm", "run", "serve", "--", "--host", "0.0.0.0", "--no-open"]
 
 # Stage 3b: Serve with Caddy.
 FROM caddy:2-alpine as caddy

--- a/docs/deployment/docker/_partials/_dockerfile-pnpm.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-pnpm.mdx
@@ -18,7 +18,7 @@ WORKDIR /opt/docusaurus
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the development server.
-CMD [ -d "node_modules" ] && pnpm start || pnpm install && pnpm start --host 0.0.0.0
+CMD [ -d "node_modules" ] && pnpm start --host 0.0.0.0 || pnpm install && pnpm start --host 0.0.0.0
 
 # Stage 2b: Production build mode.
 FROM base as prod
@@ -36,7 +36,7 @@ FROM prod as serve
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the production server.
-CMD ["pnpm", "serve", "--host", "0.0.0.0", "--no-open"]
+CMD ["pnpm", "serve", "--host", "--", "0.0.0.0", "--no-open"]
 
 # Stage 3b: Serve with Caddy.
 FROM caddy:2-alpine as caddy

--- a/docs/deployment/docker/_partials/_dockerfile-yarn.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-yarn.mdx
@@ -18,7 +18,7 @@ WORKDIR /opt/docusaurus
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the development server.
-CMD [ -d "node_modules" ] && yarn start || yarn install && yarn start --host 0.0.0.0
+CMD [ -d "node_modules" ] && yarn start --host 0.0.0.0 || yarn install && yarn start --host 0.0.0.0
 
 # Stage 2b: Production build mode.
 FROM base as prod
@@ -36,7 +36,7 @@ FROM prod as serve
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the production server.
-CMD ["yarn", "serve", "--host", "0.0.0.0", "--no-open"]
+CMD ["yarn", "serve", "--host", "--", "0.0.0.0", "--no-open"]
 
 # Stage 3b: Serve with Caddy.
 FROM caddy:2-alpine as caddy


### PR DESCRIPTION
This dockerfiles provided in the guide are not 100% working (as of docusaurus 3.2.x at least, haven't tested with earlier versions)

The problem is that the `--host` parameter isn't provided to the correct command, which results in the following error:

```
serve-1  |
serve-1  | > documentation@0.0.0 serve
serve-1  | > docusaurus serve 0.0.0.0
serve-1  |
serve-1  | [INFO] Starting the development server...
serve-1  |
serve-1  | [ERROR] [Error: ENOENT: no such file or directory, lstat '/opt/docusaurus/0.0.0.0'] {
serve-1  |   errno: -2,
serve-1  |   code: 'ENOENT',
serve-1  |   syscall: 'lstat',
serve-1  |   path: '/opt/docusaurus/0.0.0.0'
serve-1  | }
serve-1  | [INFO] Docusaurus version: 3.3.2
serve-1  | Node version: v20.13.1
```

What one should see instead in the output is:

```
serve-1  |
serve-1  | > documentation@0.0.0 serve
serve-1  | > docusaurus serve --host 0.0.0.0
serve-1  |
serve-1  | [INFO] Starting the development server...
serve-1  | [SUCCESS] Docusaurus website is running at: http://localhost:3000/
serve-1  | ℹ Compiling Client
serve-1  | ✔ Client: Compiled successfully in 4.60s
serve-1  | client (webpack 5.91.0) compiled successfully

```

Note the difference in the serve command:

```diff
- serve-1  | > docusaurus serve 0.0.0.0
+ serve-1  | > docusaurus serve --host 0.0.0.0
```

Additionally this also fixes a missing `--host` parameter for `CMD` in the `dev` target, which causes `connection reset by peer` errors when trying to connect to the application in the container.