### PR TITLE
Add note on --poll option for docker deployment

### DIFF
--- a/docs/deployment/docker/_partials/_dockerfile-npm.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-npm.mdx
@@ -18,7 +18,7 @@ WORKDIR /opt/docusaurus
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the development server.
-CMD [ -d "node_modules" ] && npm run start --host 0.0.0.0 || npm run install && npm run start --host 0.0.0.0
+CMD [ -d "node_modules" ] && npm run start --host 0.0.0.0 --poll 1000 || npm run install && npm run start --host 0.0.0.0 --poll 1000
 
 # Stage 2b: Production build mode.
 FROM base as prod

--- a/docs/deployment/docker/_partials/_dockerfile-pnpm.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-pnpm.mdx
@@ -18,7 +18,7 @@ WORKDIR /opt/docusaurus
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the development server.
-CMD [ -d "node_modules" ] && pnpm start --host 0.0.0.0 || pnpm install && pnpm start --host 0.0.0.0
+CMD [ -d "node_modules" ] && pnpm start --host 0.0.0.0 --poll 1000 || pnpm install && pnpm start --host 0.0.0.0 --poll 1000
 
 # Stage 2b: Production build mode.
 FROM base as prod

--- a/docs/deployment/docker/_partials/_dockerfile-yarn.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-yarn.mdx
@@ -18,7 +18,7 @@ WORKDIR /opt/docusaurus
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the development server.
-CMD [ -d "node_modules" ] && yarn start --host 0.0.0.0 || yarn install && yarn start --host 0.0.0.0
+CMD [ -d "node_modules" ] && yarn start --host 0.0.0.0 --poll 1000 || yarn install && yarn start --host 0.0.0.0 --poll 1000
 
 # Stage 2b: Production build mode.
 FROM base as prod

--- a/docs/deployment/docker/index.mdx
+++ b/docs/deployment/docker/index.mdx
@@ -76,7 +76,21 @@ This can be done from your package.json:
 ```
 Or in your Dockerfile as an argument to your project’s start command:
 ```bash
-CMD ["npm", "start", “--host”, “0.0.0.0”]
+CMD ["npm", "start", "--", "--host", "0.0.0.0"]
+```
+
+In order to enable live-reloading in a Docker environment, we can use `--poll` option (See [options](https://docusaurus.io/docs/cli#options) for more details):
+
+```bash
+ "scripts": {
+	"docusaurus": "docusaurus",
+	"start": "docusaurus start --poll 1000",
+```
+
+Or in your Dockerfile as an argument to your project’s start command:
+
+```bash
+CMD ["npm", "start", "--", "--poll", "1000"]
 ```
 
 ## Building the Docker Image


### PR DESCRIPTION
Adds a note on `--poll` option to enable live reload inside a docker container.
I think this significantly improves development experience when working with docker and eliminates the need to re-build on each change.