### PR TITLE
Fix line in JS code for Columns component

### DIFF
--- a/docs/component-library/new/Columns/index.mdx
+++ b/docs/component-library/new/Columns/index.mdx
@@ -39,7 +39,7 @@ Docusaurus uses the Infima framework for styling layout. The components describe
       return (
         // This section encompasses the columns that we will integrate with children from a dedicated component to allow the addition of columns as needed 
         <div className="container center">
-              <div className={clsx('row' , className)} style={style}} > 
+              <div className={clsx('row', className)} style={style}>
                 {children}    
             </div>
         </div> 


### PR DESCRIPTION
This small edit fixes the JS so Docusaurus can build correctly.

<img width="1110" alt="Screenshot 2024-10-11 at 4 10 16 PM" src="https://github.com/user-attachments/assets/e70b3105-0a50-4f44-aa38-b8a96c783c5c">
