### PR TITLE
Fix: dockerfile cmd for npm and pnpm

### DIFF
--- a/docs/deployment/docker/_partials/_dockerfile-npm.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-npm.mdx
@@ -18,7 +18,7 @@ WORKDIR /opt/docusaurus
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the development server.
-CMD [ -d "node_modules" ] && npm run start --host 0.0.0.0 --poll 1000 || npm run install && npm run start --host 0.0.0.0 --poll 1000
+CMD [ -d "node_modules" ] && npm run start -- --host 0.0.0.0 --poll 1000 || npm install && npm run start -- --host 0.0.0.0 --poll 1000
 
 # Stage 2b: Production build mode.
 FROM base as prod

--- a/docs/deployment/docker/_partials/_dockerfile-pnpm.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-pnpm.mdx
@@ -18,7 +18,7 @@ WORKDIR /opt/docusaurus
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the development server.
-CMD [ -d "node_modules" ] && pnpm start --host 0.0.0.0 --poll 1000 || pnpm install && pnpm start --host 0.0.0.0 --poll 1000
+CMD [ -d "node_modules" ] && pnpm start -- --host 0.0.0.0 --poll 1000 || pnpm install && pnpm start -- --host 0.0.0.0 --poll 1000
 
 # Stage 2b: Production build mode.
 FROM base as prod
@@ -36,7 +36,7 @@ FROM prod as serve
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the production server.
-CMD ["pnpm", "serve", "--host", "0.0.0.0", "--no-open"]
+CMD ["pnpm", "serve", "--", "--host", "0.0.0.0", "--no-open"]
 
 # Stage 3b: Serve with Caddy.
 FROM caddy:2-alpine as caddy

--- a/docs/deployment/docker/index.mdx
+++ b/docs/deployment/docker/index.mdx
@@ -117,7 +117,7 @@ Depending on stage / target you will need to run the docker image differently.
   To run the `dev` target you will need to run the following command:
 
   ```bash
-  docker run --rm -d -p 3000:3000 -v $(pwd):/var/docusaurus <tag>
+  docker run --rm -d -p 3000:3000 -v $(pwd):/opt/docusaurus <tag>
   ```
 
   If using PowerShell you will need to use `${pwd}` instead of `$(pwd)`. On some systems you may need to replace `$(pwd)` with `.` or the full path to the directory you want to mount.


### PR DESCRIPTION
The Dockerfile in the document contained an incorrect `npm` command that caused build failures during the image creation process.
The error appeared in the following lines:

```
CMD [ -d "node_modules" ] && npm run start --host 0.0.0.0 --poll 1000 || npm run install && npm run start --host 0.0.0.0 --poll 1000
```
In npm and pnpm start, --host 0.0.0.0 --poll 1000 are additional parameters. If you need to pass these parameters to the actual script, you must use -- to separate them.


Another problem is that the file path is wrong. In the Dockerfile, it is `/opt/docusaurus`, but here it is `/var/docusaurus`.

```
docker run --rm -d -p 3000:3000 -v $(pwd):/var/docusaurus <tag>
```
