### PR TITLE
Add plugin: Asyntai AI Chatbot

### DIFF
--- a/data/plugins/asyntai.chatbot.yaml
+++ b/data/plugins/asyntai.chatbot.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://docusaurus.community/schema/plugin/1.0.0.json
+id: asyntai.chatbot
+name: "Asyntai AI Chatbot"
+description: "Adds an AI chat assistant that answers visitor questions from your own documentation, in 80+ languages."
+preview: null
+website: "https://www.npmjs.com/package/docusaurus-plugin-asyntai"
+source: "https://github.com/asyntai/docusaurus-plugin-asyntai"
+author: "asyntai"
+tags:
+  - "utility"
+  - "integration"
+minimumVersion: "2.0.0"
+status: "maintained"
+npmPackages:
+  - "docusaurus-plugin-asyntai"


### PR DESCRIPTION
Adds the Asyntai AI Chatbot plugin to the directory.

Submitted first via issue #68, where the Create Plugin PR from Issue workflow failed (run 32620630654) and no draft PR was created. This is the manual route from the contributing guide.

npm: https://www.npmjs.com/package/docusaurus-plugin-asyntai
Source: https://github.com/asyntai/docusaurus-plugin-asyntai